### PR TITLE
fixed route documentation mismatch for /chart

### DIFF
--- a/API.md
+++ b/API.md
@@ -10,9 +10,9 @@
 - [Configuration File](#configuration-file)
 - [Environment Variables](#environment-variables)
 - [Endpoints](#endpoints)
-  - [`POST /charts`](#post-charts)
+  - [`POST /chart`](#post-chart)
     - [Form Parameters](#form-parameters)
-  - [`PUT /charts`](#put-charts)
+  - [`PUT /chart`](#put-chart)
     - [Form Parameters](#form-parameters-1)
   - [`POST /index/rebuild`](#post-indexrebuild)
     - [Form Parameters](#form-parameters-2)
@@ -34,7 +34,7 @@
 - `-P, --port <port>` - port to listen with (defaults to `8080`). *[integer]*
 - `-r, --region <string>` - AWS region (defaults to `us-east-1`. *[string]*
 - `-f, --file <path>` - Path to [configuration file](#configuration-file). *[string]*
-- `-u, --url <string>`, host + path Url to build the canonical chart link with. Defaults to _https://s3.amazonaws.com/<bucket>_ *[string]*
+- `-u, --url <string>`, host + path Url to build the canonical chart link with. Defaults to _https://s3.amazonaws.com/<bucket>/<subRepo>_ *[string]*
 
 ## Configuration File
 
@@ -64,7 +64,7 @@ The configuration file is in JSON format.
 
 ## Endpoints
 
-### `POST /charts`
+### `POST /chart`
 Allows you to post new charts to the repository.  If the name of the uploaded chart matches one in S3, the call will fail.  This call will also update the `index.yaml` manifest.
 
 #### Form Parameters
@@ -72,10 +72,10 @@ Allows you to post new charts to the repository.  If the name of the uploaded ch
 - `chart` - content of the file *[file]* **Required**
 
 ```
-curl -i -X POST -F repo=qa -F chart=@/home/bob/prometheus-0.1.0.tgz http://localhost:8080/charts
+curl -i -X POST -F repo=qa -F chart=@/home/bob/prometheus-0.1.0.tgz http://localhost:8080/chart
 ```
 
-### `PUT /charts`
+### `PUT /chart`
 Allows you to update an existing chart to the repository.  This call will also update the `index.yaml` manifest.
 
 #### Form Parameters
@@ -83,7 +83,7 @@ Allows you to update an existing chart to the repository.  This call will also u
 - `chart` - content of the file *[file]* **Required**
 
 ```
-curl -i -X PUT -F repo=qa -F chart=@/home/bob/prometheus-0.1.0.tgz http://localhost:8080/charts
+curl -i -X PUT -F repo=qa -F chart=@/home/bob/prometheus-0.1.0.tgz http://localhost:8080/chart
 ```
 
 ### `POST /index/rebuild`

--- a/Example.md
+++ b/Example.md
@@ -68,7 +68,7 @@ docker run xogroup/helm-chart-s3-publisher -a 123xyz099 -s 098abc211 -b chart-re
 ## Uploading a new chart to S3
 
 ```
-curl -i -X POST -F chart=@/home/bob/prometheus-0.1.0.tgz http://localhost:8080/charts
+curl -i -X POST -F chart=@/home/bob/prometheus-0.1.0.tgz http://localhost:8080/chart
 ```
 
 Will result in your S3 bucket having these new files
@@ -81,7 +81,7 @@ index.yaml
 ## Uploading a new chart to S3 under a `qa` prefix
 
 ```
-curl -i -X POST -F subRepo=qa -F chart=@/home/bob/prometheus-0.1.0.tgz http://localhost:8080/charts
+curl -i -X POST -F subRepo=qa -F chart=@/home/bob/prometheus-0.1.0.tgz http://localhost:8080/chart
 ```
 
 Will result in your S3 bucket having these new files


### PR DESCRIPTION
## Description
The documentation and route for `/chart` did not match.

## Related Issue
* #1 

## Motivation and Context
Very important for documentation to match up.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Documentation only (no changes to either `lib/` or `test/` files)
- [ ] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [ ] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/xogroup/helm-chart-s3-publisher/blob/master/.github/CONTRIBUTING.md) document.
- [ ] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [ ] I have updated the documentation as needed.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.