### PR TITLE
using v4 sig for s3 bucket access

### DIFF
--- a/lib/helpers/chartExist.js
+++ b/lib/helpers/chartExist.js
@@ -1,8 +1,7 @@
 'use strict';
 
 const Promise = require('bluebird');
-const AWS = require('aws-sdk');
-const S3 = new AWS.S3();
+const S3 = require('./s3');
 
 const chartExist = function () {
 

--- a/lib/helpers/downloadCharts.js
+++ b/lib/helpers/downloadCharts.js
@@ -1,8 +1,7 @@
 'use strict';
 
 const Promise = require('bluebird');
-const AWS = require('./aws');
-const S3 = new AWS.S3();
+const S3 = require('./s3');
 const Fs = require('fs');
 const Path = require('path');
 

--- a/lib/helpers/downloadIndex.js
+++ b/lib/helpers/downloadIndex.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const AWS = require('./aws');
-const S3 = new AWS.S3();
+const S3 = require('./s3');
 const Fs = require('fs');
 
 const downloadIndex = function () {

--- a/lib/helpers/downloadObject.js
+++ b/lib/helpers/downloadObject.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const AWS = require('./aws');
-const S3 = new AWS.S3();
+const S3 = require('./s3');
 const Boom = require('boom');
 
 const downloadObject = function () {

--- a/lib/helpers/s3.js
+++ b/lib/helpers/s3.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const AWS = require('./aws');
+
+module.exports = new AWS.S3({
+    signatureVersion: 'v4'
+});

--- a/lib/helpers/syncChartKeys.js
+++ b/lib/helpers/syncChartKeys.js
@@ -1,8 +1,7 @@
 'use strict';
 
 const Promise = require('bluebird');
-const AWS = require('./aws');
-const S3 = new AWS.S3();
+const S3 = require('./s3');
 
 const pageResults = function (options, keys, continuationToken, cb) {
 

--- a/lib/helpers/uploadChart.js
+++ b/lib/helpers/uploadChart.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const AWS = require('./aws');
-const S3 = new AWS.S3();
+const S3 = require('./s3');
 const Fs = require('fs');
 
 const uploadChart = function () {

--- a/lib/helpers/uploadIndex.js
+++ b/lib/helpers/uploadIndex.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const AWS = require('./aws');
-const S3 = new AWS.S3();
+const S3 = require('./s3');
 const Fs = require('fs');
 
 const uploadIndex = function () {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Refactored all `S3` access to use `v4` encryption signature.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#9 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This tool was not working for all AWS regions

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [ ] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [x] New feature (non-breaking change which adds functionality. you added at least one new test)
- [ ] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/xogroup/helm-chart-s3-publisher/blob/master/.github/CONTRIBUTING.md) document.
- [ ] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [ ] I have updated the documentation as needed.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.